### PR TITLE
Extends data collection to cover toplevel events

### DIFF
--- a/node/app.js
+++ b/node/app.js
@@ -96,7 +96,28 @@ app.post("/eval", function (req, res)
   }
 });  
 
-
+app.post("/toplevel", function(req, res) {
+  if (req.body) 
+  {
+    const split_array = req.body;
+    const collection = split_array[3];
+    let commandStr = split_array[4];
+    const obj = new Object();
+    obj.studentId = split_array[1];
+    obj.timestamp = new Date().toString();
+    obj.command = commandStr; 
+    obj.note = split_array[5];
+    const jsonString = JSON.stringify(obj);
+    const command = JSON.parse( jsonString ); // parse req.body as an object
+    db.collection(collection).insertOne(command);
+    console.log(command);
+    res.sendStatus(200); // success status
+  }
+  else
+  {
+    res.sendStatus(400);
+  }
+});
 
 app.listen(port, () => {
   console.log(`Server running on port${port}`);

--- a/src/app/dune
+++ b/src/app/dune
@@ -2,10 +2,35 @@
  (name learnocaml_app_common)
  (wrapped false)
  (flags :standard -warn-error -9-27-32)
- (modules Learnocaml_local_storage
-          Learnocaml_config
+ (modules Learnocaml_config
           Server_caller
           Learnocaml_common)
+ (preprocess
+  (per_module ((pps js_of_ocaml.ppx)
+               Learnocaml_config
+               Server_caller)
+              ((pps ppx_ocplib_i18n js_of_ocaml.ppx)
+               Learnocaml_common)))
+ (libraries
+    ocplib-json-typed.browser
+    js_of_ocaml
+    js_of_ocaml.ppx
+    js_of_ocaml.tyxml
+    jsutils
+    learnocaml_local_storage
+    learnocaml_toplevel
+    learnocaml_repository
+    learnocaml_data
+    learnocaml_api
+    sha
+    ocplib_i18n)
+)
+
+(library
+ (name learnocaml_local_storage)
+ (wrapped false)
+ (flags :standard -warn-error -9-27-32)
+ (modules Learnocaml_local_storage)
  (preprocess
   (per_module ((pps js_of_ocaml.ppx)
                Learnocaml_config
@@ -19,13 +44,11 @@
     js_of_ocaml.ppx
     js_of_ocaml.tyxml
     jsutils
-    learnocaml_toplevel
     learnocaml_repository
     learnocaml_data
     learnocaml_api
     sha
-    ocplib_i18n)
-)
+    ocplib_i18n))
 
 (executable
  (name learnocaml_index_main)

--- a/src/toplevel/dune
+++ b/src/toplevel/dune
@@ -48,6 +48,7 @@
             ocplib-json-typed
             learnocaml_toplevel_history
             learnocaml_toplevel_worker_messages
+            learnocaml_local_storage
             ocplib_i18n)
  (modules Learnocaml_toplevel_worker_caller
           Learnocaml_toplevel_output


### PR DESCRIPTION
Toplevel events (this includes typed-out commands, presses of 'eval code', and resetting the state of the toplevel) are now all recorded in the database. The data collection functions nearly identically to how we are already collecting data from grade events, with the one difference being that the toplevel events have an additional "note" field which specifies if the update is a reset or an execution.

Please let me know if you have any comments or concerns!